### PR TITLE
Include image version in computed cache key

### DIFF
--- a/src/vcpkg-utils.ts
+++ b/src/vcpkg-utils.ts
@@ -115,7 +115,12 @@ export class Utils {
     }
 
     key += "-args=" + Utils.hashCode(core.getInput(runvcpkglib.vcpkgArguments));
-    key += "-os=" + Utils.hashCode(process.platform);
+    key += "-os=" + Utils.hashCode(process.env.ImageOS ? process.env.ImageOS : process.platform);
+
+    if (process.env.ImageVersion) {
+      key += "-imageVer=" + Utils.hashCode(process.env.ImageVersion);
+    }
+
     key += "-appendedKey=" + Utils.hashCode(appendedCacheKey);
 
     // Add the triplet only if it is provided.


### PR DESCRIPTION
This hopefully offers a fix for #69, which we have been encountering. The latest update fixed the issue not being reported, but we still had issues because the version that had been cached was too old and was throwing compile errors.

```ImageOS``` is also exported as an environment variable (for all of Windows, Linux, macOS on GitHub Actions) though I haven't used it here. It may be worth incorporating it too, or replacing the use of ```process.platform``` with ```process.env.ImageOS```.

(It may be the ```if``` statement is also redundant, and we can always assume these variables are present.)