### PR TITLE
Fix sample link in README: vcpkg NOT as submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The dependencies specified in the vcpkg.json file are installed when CMake runs 
 |Sample scenario|Notes|
 |:-:|:-:|
 |[vcpkg as submodule, CMake with vcpkg toolchain in a CMakePreset.json configuration](https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-ninja-vcpkg_submod.yml)| Uses `CMake`, `Ninja` and `vcpkg`|
-|[vcpkg NOT as submodule, CMake with vcpkg toolchain in a CMakePreset.json configuration](https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-ninja-vcpkg_submod.yml)|Uses `CMake`, `Ninja` and `vcpkg`|
+|[vcpkg NOT as submodule, CMake with vcpkg toolchain in a CMakePreset.json configuration](https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-ninja-vcpkg.yml)|Uses `CMake`, `Ninja` and `vcpkg`|
 |[`run-vcpkg` runs 'vcpkg install'](https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-ninja-vcpkg-install.yml)|Uses `CMake`, `Ninja` and `vcpkg`|
 <br>
 


### PR DESCRIPTION
The link for the `vcpkg NOT as submodule` in README is referencing the `vcpkg as submodule` sample.